### PR TITLE
added minor fixes and some changes. New version

### DIFF
--- a/alabcdk/redshift.py
+++ b/alabcdk/redshift.py
@@ -202,7 +202,7 @@ class RedshiftServerless(RedshiftBase):
             iam_roles=[self.redshift_role.role_arn],
         )
 
-        pub_subnets = [subnet.subnet_id for subnet in self.vpc.public_subnets]
+        isolated_subnets = [subnet.subnet_id for subnet in self.vpc.isolated_subnets]
 
         self.redshift_workgroup = aws_redshiftserverless.CfnWorkgroup(
             self,
@@ -211,7 +211,9 @@ class RedshiftServerless(RedshiftBase):
             base_capacity=base_capacity,
             enhanced_vpc_routing=False,
             namespace_name=self.redshift_namespace.namespace_name,
-            publicly_accessible=True,
+            publicly_accessible=False,
             security_group_ids=[self.security_group.security_group_id],
-            subnet_ids=pub_subnets,
+            subnet_ids=isolated_subnets,
         )
+
+        self.redshift_workgroup.add_depends_on(self.redshift_namespace)

--- a/alabcdk/utils.py
+++ b/alabcdk/utils.py
@@ -71,8 +71,8 @@ def get_params(allvars: dict) -> dict:
     :param locals: Dictionary with local variables
     :return: Combined dictionary
     """
-    assert(allvars.get("self"))
-    assert("kwargs" in allvars)
+    assert (allvars.get("self"))
+    assert ("kwargs" in allvars)
     kwargs = allvars.get("kwargs")
     kwargs = kwargs or {}
     cls = type(allvars["self"])

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, "requirements.txt")) as f:
 
 setup(
     name='alabcdk',
-    version='1.1.11',
+    version='1.1.12',
     description='Useful CDK constructs',
     url='https://github.com/aditrologistics/alabcdk.git',
     author='Jesper Högström',


### PR DESCRIPTION
- Change so we get subnet ids from isolated subnets and not public since we don't use them
- rm public access flag of redshfit module
- Added that redshift workspace depends on the namespace so the namespace is instantiated before using it in workspace
- flake8 stuff
- new version which indicate that it works with current DL repo